### PR TITLE
feat(text): add PlusText component with customizable styles and semantic rendering

### DIFF
--- a/dev/demo/text.html
+++ b/dev/demo/text.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Component Test Page</title>
+    <script type="module" src="../cdn/components/index.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        padding: 2rem;
+        font-family: 'Inter', sans-serif;
+      }
+
+      .col {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <plus-text kind="display">Ana Başlık</plus-text>
+    <plus-text kind="heading1">Ana Başlık</plus-text>
+    <plus-text kind="heading2">Ana Başlık</plus-text>
+    <plus-text kind="title1">Ana Başlık</plus-text>
+    <plus-text kind="title2">Ana Başlık</plus-text>
+    <plus-text kind="body">Bu bir paragraf metnidir.</plus-text>
+    <plus-text kind="body-accent">Bu bir paragraf metnidir.</plus-text>
+    <plus-text kind="helper">Bu bir yardımcı metindir.</plus-text>
+    <plus-text kind="caption">Bu bir alt yazı metnidir.</plus-text>
+  </body>
+</html>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,3 +22,4 @@ export * from './popover';
 export * from './tooltip';
 export * from './input';
 export * from './popconfirm';
+export * from './text';

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,0 +1,5 @@
+import { PlusText } from './text.js';
+
+export * from './text.js';
+
+customElements.define('plus-text', PlusText);

--- a/src/components/text/text.style.ts
+++ b/src/components/text/text.style.ts
@@ -1,0 +1,29 @@
+import { tv } from 'tailwind-variants';
+
+export const textStyle = tv({
+  base: ['plus-text', 'plus-ui-element'],
+  variants: {
+    kind: {
+      display:
+        'font-bold text-6xl text-color-default',
+      heading1:
+        'font-semibold text-3xl text-color-default',
+      heading2:
+        'font-semibold text-2xl text-color-default',
+      title1:
+        'font-medium text-xl text-color-default',
+      title2:
+        'font-medium text-lg text-color-default',
+      body: 'font-normal text-base text-color-default',
+      'body-accent':
+        'font-medium text-base text-color-default',
+      helper:
+        'font-medium text-sm text-color-placeholder',
+      caption:
+        'font-normal text-sm text-color-caption',
+    },
+  },
+  defaultVariants: {
+    kind: 'body',
+  },
+});

--- a/src/components/text/text.ts
+++ b/src/components/text/text.ts
@@ -1,0 +1,80 @@
+import { property } from 'lit/decorators.js';
+import { html, literal } from 'lit/static-html.js';
+import Tailwind from '../base/tailwind-base';
+import { textStyle } from './text.style';
+
+/**
+ * @tag plus-text
+ *
+ * Text component for displaying text with various styles based on the design system.
+ * Renders the appropriate semantic HTML tag based on the `kind` property (e.g., h1, h2, p, div).
+ *
+ * @slot - The default slot for the text content.
+ *
+ * @csspart base - The component's base wrapper element (e.g., h1, p, div).
+ *
+ * @cssproperty --i-text-color - Inherited text color variable.
+ */
+export class PlusText extends Tailwind {
+  /**
+   * Defines the visual style and semantic meaning of the text.
+   * - `display`: For large, prominent display text (rendered as div).
+   * - `heading1`: For the main heading (rendered as h1).
+   * - `heading2`: For secondary headings (rendered as h2).
+   * - `title1`: For primary titles (rendered as h3 - adjust as needed).
+   * - `title2`: For secondary titles (rendered as h4 - adjust as needed).
+   * - `body`: For standard body text (rendered as p) (default).
+   * - `body-accent`: For emphasized body text (rendered as p).
+   * - `helper`: For helper text, often used with form elements (rendered as div).
+   * - `caption`: For small caption text (rendered as div).
+   * @default 'body'
+   */
+  @property({ type: String })
+  kind:
+    | 'display'
+    | 'heading1'
+    | 'heading2'
+    | 'title1'
+    | 'title2'
+    | 'body'
+    | 'body-accent'
+    | 'helper'
+    | 'caption' = 'body';
+
+  private getTag() {
+    switch (this.kind) {
+      case 'heading1':
+        return literal`h1`;
+      case 'heading2':
+        return literal`h2`;
+      case 'title1':
+        return literal`h3`; // Or another appropriate heading level
+      case 'title2':
+        return literal`h4`; // Or another appropriate heading level
+      case 'body':
+      case 'body-accent':
+        return literal`p`;
+      case 'display':
+      case 'helper':
+      case 'caption':
+      default:
+        return literal`div`; // Use div for non-paragraph/heading types
+    }
+  }
+
+  /**
+   * Renders the text component with the appropriate styles and semantic tag.
+   * @returns The rendered template.
+   */
+  override render() {
+    const classes = textStyle({ kind: this.kind });
+    const tag = this.getTag();
+
+    // Render the dynamic tag using the result from getTag()
+    return html`
+      <${tag} part="base" class=${classes}>
+        <slot></slot>
+      </${tag}>
+    `;
+  }
+}


### PR DESCRIPTION
- Introduced the PlusText component for displaying text with various styles based on the design system.
- Implemented dynamic rendering of semantic HTML tags based on the `kind` property.
- Added associated styles using Tailwind CSS variants.
- Updated index files to export the new component.